### PR TITLE
Fixed (?) onready bug affecting odd situation in Firefox

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -115,12 +115,10 @@ function document_onReadyStateChange(){
 }
 
 if (!isReady) {
-    on(window, "DOMContentLoaded", dom_onLoaded);
     on(document, "DOMContentLoaded", dom_onLoaded);
     
     if (isHostMethod(window, "ActiveXObject")) {
         on(document, "readystatechange", document_onReadyStateChange);
-        on(window, "load", dom_onLoaded);
         
         if (window === top) {
             (function doScrollCheck(){
@@ -139,6 +137,9 @@ if (!isReady) {
             }());
         }
     }
+
+    // A fallback to window.onload, that will always work
+    on(window, "load", dom_onLoaded);
 }
 /**
  * This will add a function to the queue of functions to be run once the DOM reaches a ready state.


### PR DESCRIPTION
Hey Oyvind,

I was working with easyXDM when I arrived at a state in Firefox where easyXDM's onready detection wasn't firing -- none of the supplied events were hitting. So, I compared easyXDM's onready code to jQuery's, and noticed jQuery was putting a catch-all 'load' event just in case DOMContentLoaded didn't hit. I made the change to the source, and it fixed my issue.

Please take a look.

Cheers,
- Ben
