### PR TITLE
Fixed a bug in the SameOriginTransport but not sure if the fix is not too ugly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build.number
 src/.*
 *.prefs
 build.secret.properties
+src/tests/easyXDM.debug.js

--- a/build.xml
+++ b/build.xml
@@ -113,7 +113,11 @@
 			<fileset file= "${project.src.dir}/changes.txt"/>
 			<fileset file= "tools/json2.js"/>
 		</copy>
-		
+
+		<copy todir="${project.src.dir}/tests">
+			<fileset file="work/easyXDM.debug.js"/>
+		</copy>
+
 		<copy todir="${project.build.artifactdir}v${project.build.version}/example">
 			<fileset dir="${project.src.dir}/example"/>
 		</copy>

--- a/src/begin_scope.txt
+++ b/src/begin_scope.txt
@@ -1,7 +1,1 @@
 (function (window, document, location, setTimeout, decodeURIComponent, encodeURIComponent) {
-	// Double inclusion safeguard
-	// If you want to have easyXDM scoped to a closure (for instance to avoid version collisions etc, 
-	// just define a variable 'easyXDM' as undefined prior to easyXDM's initialization closure.
-	if (typeof easyXDM != "undefined") {
-		return;
-	}

--- a/src/end_scope.txt
+++ b/src/end_scope.txt
@@ -1,1 +1,2 @@
+global.easyXDM = easyXDM;
 })(window, document, location, window.setTimeout, decodeURIComponent, encodeURIComponent);

--- a/src/stack/SameOriginTransport.js
+++ b/src/stack/SameOriginTransport.js
@@ -1,5 +1,5 @@
 /*jslint evil: true, browser: true, immed: true, passfail: true, undef: true, newcap: true*/
-/*global easyXDM, window, escape, unescape, getLocation, appendQueryParameters, createFrame, debug, un, on, apply, whenReady, IFRAME_PREFIX*/
+/*global easyXDM, window, escape, unescape, getLocation, appendQueryParameters, createFrame, debug, un, on, apply, whenReady, getParentObject, IFRAME_PREFIX*/
 //
 // easyXDM
 // http://easyxdm.net/

--- a/src/tests/index.html
+++ b/src/tests/index.html
@@ -4,7 +4,16 @@
         <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
         <meta http-equiv="X-UA-Compatible" content="IE=100">
         <title>easyTest results</title>
-        <script type="text/javascript" src="../easyXDM.debug.js">
+        <script type="text/javascript" src="easyXDM.debug.js">
+        </script>
+        <script type="text/javascript">
+          easyXDM._test_global = true;
+        </script>
+        <script type="text/javascript" src="easyXDM.debug.js">
+        </script>
+        <script type="text/javascript">
+          // Used in the noConflict test
+          var modules = { easyXDM: easyXDM.noConflict("modules") };
         </script>
         <script type="text/javascript">
             if (location.href.indexOf("src") !== -1) {

--- a/src/tests/test_namespace.html
+++ b/src/tests/test_namespace.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html>
+    <head>
+        <title>easyXDM</title>
+        <script type="text/javascript" src="./easyXDM.debug.js">
+        </script>
+        <script type="text/javascript">
+            var modules = {
+              easyXDM: easyXDM.noConflict("modules")
+            };
+
+            var transport;
+            window.onload = function(){
+                transport = new modules.easyXDM.Socket({
+                    local: "../name.html",
+                    onMessage: function(message, origin){
+                        // Echo back the message
+                        transport.postMessage(message);
+                    }
+                });
+            };
+
+            window.onunload = function(){
+                if (transport) {
+                    transport.destroy();
+                }
+            };
+        </script>
+    </head>
+    <body>
+    </body>
+</html>

--- a/src/tests/tests.js
+++ b/src/tests/tests.js
@@ -1,5 +1,5 @@
 /*jslint evil: true, browser: true, immed: true, passfail: true, undef: true, newcap: true*/
-/*global easyTest, easyXDM, window, checkAcl, getDomainName, getLocation, appendQueryParameters*/
+/*global easyTest, easyXDM, window*/
 var REMOTE = (function(){
     var remote = location.href;
     switch (location.host) {
@@ -115,22 +115,22 @@ function runTests(){
         steps: [{
             name: "getDomainName",
             run: function(){
-                return getDomainName(this.url1) === "foo.bar";
+                return easyXDM.getDomainName(this.url1) === "foo.bar";
             }
         }, {
             name: "getLocation",
             run: function(){
-                return getLocation(this.url1) === "http://foo.bar";
+                return easyXDM.getLocation(this.url1) === "http://foo.bar";
             }
         }, {
             name: "getLocation with :port",
             run: function(){
-                return getLocation(this.url2) === "http://foo.bar:80";
+                return easyXDM.getLocation(this.url2) === "http://foo.bar:80";
             }
         }, {
             name: "appendQueryParameters",
             run: function(){
-                return appendQueryParameters(this.url2, {
+                return easyXDM.appendQueryParameters(this.url2, {
                     g: "h"
                 }) ===
                 "http://foo.bar:80/a/b/c?d=e&g=h#f";
@@ -149,27 +149,27 @@ function runTests(){
         steps: [{
             name: "Match complete string",
             run: function(){
-                return checkAcl(this.acl, "http://www.domain.invalid");
+                return easyXDM.checkAcl(this.acl, "http://www.domain.invalid");
             }
         }, {
             name: "Match *",
             run: function(){
-                return checkAcl(this.acl, "http://www.domaina.com");
+                return easyXDM.checkAcl(this.acl, "http://www.domaina.com");
             }
         }, {
             name: "Match ?",
             run: function(){
-                return checkAcl(this.acl, "http://domainb.com");
+                return easyXDM.checkAcl(this.acl, "http://domainb.com");
             }
         }, {
             name: "Match RegExp",
             run: function(){
-                return checkAcl(this.acl, "http://domcccain.com");
+                return easyXDM.checkAcl(this.acl, "http://domcccain.com");
             }
         }, {
             name: "No match",
             run: function(){
-                return !checkAcl(this.acl, "http://foo.com");
+                return !easyXDM.checkAcl(this.acl, "http://foo.com");
             }
         }]
     }, {
@@ -560,6 +560,53 @@ function runTests(){
             timeout: 5000,
             run: function(){
                 this.transport.postMessage(this.expectedMessage);
+            }
+        }]
+    }, {
+        name: "test easyXDM.noConflict {SameOriginTransport}",
+        setUp: function(){
+            this.expectedMessage = ++i + "_abcd1234%@¤/";
+        },
+        steps: [{
+            name: "window.easyXDM is released {namespace}",
+            timeout: 5000,
+            run: function(){
+                this.notifyResult(window.easyXDM._test_global &&
+                    typeof modules.easyXDM._test_global == "undefined");
+            }
+        }, {
+            name: "onReady is fired {namespace}",
+            timeout: 5000,
+            run: function(){
+                var scope = this;
+                var messages = 0;
+                this.transport = new modules.easyXDM.Socket({
+                    protocol: "4",
+                    remote: LOCAL + "/test_namespace.html",
+                    onMessage: function(message, origin){
+                        if (scope.expectedMessage === message) {
+                            if (++messages === 2) {
+                                scope.notifyResult(true);
+                            }
+                        }
+                    },
+                    onReady: function(){
+                        scope.notifyResult(true);
+                    }
+                });
+            }
+        }, {
+            name: "message is echoed back {namespace}",
+            timeout: 5000,
+            run: function(){
+                this.transport.postMessage(this.expectedMessage);
+                this.transport.postMessage(this.expectedMessage);
+            }
+        }, {
+            name: "destroy {namespace}",
+            run: function(){
+                this.transport.destroy();
+                return ((document.getElementsByTagName("iframe").length === 0));
             }
         }]
     }, {


### PR DESCRIPTION
Basically, the bug is in the SameOriginTransport.js:87 where the library tries to locate parent window's easyXDM instance by looking for parent.easyXDM. That does not work is the instance is namespaced. For example, our instance is under DISQUS.net.easyXDM so parent.easyXDM is almost always undefined (and when it is not undefined, we do not want to use it).

My fix is not too pretty, I just defined a new method addToNamespace that stores provided namespace in a closure and later another private function, getParentObject, breaks it into objects and returns a reference to the exact object we want.

I was going to write a test case but that does not seem to be that trivial with your testing framework. I will still write it but I want your feedback on the issue first. Right now, this behavior is heavily tested with our Selenium tests.

I committed the latest version to our code base today and here how we use it:

```
// Outer closure
(function () {
var easyXDM = undefined;

// easyXDM closure
(function (window, document, ...) {
    // easyXDM code, unmodified (except for the bugfix)
})(window, document, ...);

easyXDM.addToNamespace("DISQUS.net");
DISQUS.net = { easyXDM: easyXDM };

}()); // End of outer closure
```
