### PR TITLE
Legacy WebKit browsers still use readyState == 'loaded' and we expect it to be 'complete'

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -101,9 +101,14 @@ else {
 /*
  * Cross Browser implementation of DOMContentLoaded.
  */
-var isReady = false, domReadyQueue = [];
+var isReady = false, domReadyQueue = [], state;
 if ("readyState" in document) {
-    isReady = document.readyState == "complete";
+    // If browser is WebKit-powered, check for both 'loaded' (legacy browsers) and
+    // 'interactive' (HTML5 specs, recent WebKit builds) states.
+    state = document.readyState;
+    isReady = state == "complete" ||
+        (~navigator.userAgent.indexOf('AppleWebKit/') &&
+            (state == "loaded" || state == "interactive"));
 }
 else {
     // If readyState is not supported in the browser, then in order to be able to fire whenReady functions apropriately


### PR DESCRIPTION
We hit an issue on one of our sites where easyXDM was not firing whenReady event from time to time. That happened only when our script (and easyXDM) were loaded after DOMContentLoaded event was fired. The library expects readyState to be "complete" and if it is not, we set a listener on a DOMContentLoaded event.

The problem is that legacy WebKit browsers (current Safari, for example) still implement readyState to be equal to "loaded" so isReady can be false even after DOMContentLoaded was fired.

According to the HTML5 spec, the state is supposed to be "interactive" but WebKit used to use "loaded" instead. they recently committed the change but legacy browsers still use and will always use non-HTML5 version.

And since there are problems of checking for "loaded" in IE9, my commit explicitly checks if the browser is WebKit-powered.

Relevant links:
- http://www.w3.org/TR/html5/dom.html#dom-document-readystate
- https://bugs.webkit.org/show_bug.cgi?id=45119
- https://bugs.webkit.org/attachment.cgi?id=66658&action=prettypatch
