### PR TITLE
easyXDM adds extra scroll on right-to-left pages

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -474,8 +474,7 @@ function createFrame(config){
     if (!config.container) {
         // This needs to be hidden like this, simply setting display:none and the like will cause failures in some browsers.
         frame.style.position = "absolute";
-        frame.style.left = "-2000px";
-        frame.style.top = "0px";
+        frame.style.top = "-2000px";
         config.container = document.body;
     }
     


### PR DESCRIPTION
If page has body[dir=rtl] or CSS rule direction=rtl, the use of hidden easyXDM iframe adds extra scroll to the page because left=-2000px should be right=-2000px on those pages.

The patch was extracted from our internal easyXDM fork at Disqus.
