### PR TITLE
Apply attributes before appending iFrame into the DOM

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -483,11 +483,12 @@ function createFrame(config){
         config.container = document.body;
     }
     
+    // transfer properties to the frame
+    apply(frame, config.props);
+
     frame.border = frame.frameBorder = 0;
     config.container.insertBefore(frame, config.container.firstChild);
     
-    // transfer properties to the frame
-    apply(frame, config.props);
     return frame;
 }
 


### PR DESCRIPTION
Some attributes are not settable after the iFrame is in the document. In my case, the allowTransparency attribute in IE did not seem to apply after the iFrame was in the page. I thought there were other examples of this, but Googling around yielded minimal results.
