### PR TITLE
Apply attrs before inserting into DOM, apply src after 

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -483,11 +483,21 @@ function createFrame(config){
         config.container = document.body;
     }
     
+    // HACK for some reason, IE needs the source set
+    // after the frame has been appended into the DOM
+    // so remove the src, and set it afterwards
+    var src = config.props.src;
+    delete config.props.src;
+
     // transfer properties to the frame
     apply(frame, config.props);
 
     frame.border = frame.frameBorder = 0;
     config.container.insertBefore(frame, config.container.firstChild);
+
+    // HACK see above
+    frame.src = src;
+    config.props.src = src;
     
     return frame;
 }


### PR DESCRIPTION
We found that IE craps out when you set the src before inserting the frame into the DOM. For whatever reason, setting the src after the frame has been inserted fixes the problem. Certain other attributes, like "scrolling" and "allowTransparency" can not be set after the frame has been inserted, to apply all other attributes before the frame is in the DOM.
