### PR TITLE
success() and error() callbacks dropped in window.opener example

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -30,16 +30,38 @@ var emptyFn = Function.prototype;
 var reURI = /^((http.?:)\/\/([^:\/\s]+)(:\d+)*)/; // returns groups for protocol (2), domain (3) and port (4) 
 var reParent = /[\-\w]+\/\.\.\//; // matches a foo/../ expression 
 var reDoubleSlash = /([^:])\/\//g; // matches // anywhere but in the protocol
+var reFunction = /^function/; // matches the opening of a function declaration
 var namespace = ""; // stores namespace under which easyXDM object is stored on the page (empty if object is global)
 var easyXDM = {};
 var _easyXDM = window.easyXDM; // map over global easyXDM in case of overwrite
 var IFRAME_PREFIX = "easyXDM_";
 var HAS_NAME_PROPERTY_BUG;
+var HAS_FUNCTION_RECAST_BUG = false/*@cc_on || ((ScriptEngineMajorVersion()+(ScriptEngineMinorVersion()/10)) <= 5.8)@*/;
 var useHash = false; // whether to use the hash over the query
+
 // #ifdef debug
 var _trace = emptyFn;
 // #endif
 
+// http://www.kilometer0.com/blog/code/internet-explorer-ie-cross-window-javascript-object-typeof-bug/
+function isCallableFunction(fn) {
+    if (typeof fn === "function") {
+        return true;
+    }
+
+    // IE specific (object, and looking at an object)
+    if (HAS_FUNCTION_RECAST_BUG && typeof fn === "object" && typeof fn.call !== "undefined" && typeof fn.apply !== "undefined") {
+        try {
+            return reFunction.test(fn.toString());
+        }
+        catch(e) {
+            return false; // either toString() can't be called, or other assorted errors
+        }
+    }
+    
+    return false;
+}
+// end
 
 // http://peter.michaux.ca/articles/feature-detection-state-of-the-art-browser-scripting
 function isHostMethod(object, property){

--- a/src/stack/RpcBehavior.js
+++ b/src/stack/RpcBehavior.js
@@ -1,5 +1,5 @@
 /*jslint evil: true, browser: true, immed: true, passfail: true, undef: true, newcap: true*/
-/*global easyXDM, window, escape, unescape, undef, getJSON, debug, emptyFn, isArray */
+/*global easyXDM, window, escape, unescape, undef, getJSON, debug, emptyFn, isArray, isCallableFunction */
 //
 // easyXDM
 // http://easyxdm.net/
@@ -74,9 +74,9 @@ easyXDM.stack.RpcBehavior = function(proxy, config){
                 method: method
             };
             
-            if (l > 0 && typeof arguments[l - 1] === "function") {
+            if (l > 0 && isCallableFunction(arguments[l - 1])) {
                 //with callback, procedure
-                if (l > 1 && typeof arguments[l - 2] === "function") {
+                if (l > 1 && isCallableFunction(arguments[l - 2])) {
                     // two callbacks, success and error
                     callback = {
                         success: arguments[l - 2],


### PR DESCRIPTION
Cleaned up into a single commit using squash to represent the scope of change for #51. Includes all feedback from oyvindkinsey.
