### PR TITLE
inline include of easyXDM causes an illegal token error

### DIFF
--- a/src/DomHelper.js
+++ b/src/DomHelper.js
@@ -56,7 +56,7 @@ easyXDM.DomHelper = {
             // #ifdef debug
             debug.log("loading external JSON");
             // #endif
-            document.write('<script type="text/javascript" src="' + path + '"></script>');
+            document.write('<scr'+'ipt type="text/javascript" src="' + path + '"></scr'+'ipt>');
         }
         // #ifdef debug
         else {


### PR DESCRIPTION
the requiresJSON call was outputting a literal script tag, which would cause issues when the easyXDM library was inlined in a page. The fix is to break the script tags up into incomplete strings.
