### PR TITLE
window.parent not sufficient to prevent spoofing

### DIFF
--- a/src/stack/FrameElementTransport.js
+++ b/src/stack/FrameElementTransport.js
@@ -88,7 +88,7 @@ easyXDM.stack.FrameElementTransport = function(config){
             else {
                 // This is to mitigate origin-spoofing
                 if (document.referrer && getLocation(document.referrer) != query.xdm_e) {
-                    window.parent.location = query.xdm_e;
+                    window.top.location = query.xdm_e;
                 }
                 send = window.frameElement.fn(function(msg){
                     pub.up.incoming(msg, targetOrigin);

--- a/src/stack/NixTransport.js
+++ b/src/stack/NixTransport.js
@@ -139,7 +139,7 @@ easyXDM.stack.NixTransport = function(config){
             else {
                 // This is to mitigate origin-spoofing
                 if (document.referrer && getLocation(document.referrer) != query.xdm_e) {
-                    window.parent.location = query.xdm_e;
+                    window.top.location = query.xdm_e;
                 }
                 try {
                     // by storing this in a variable we negate replacement attacks


### PR DESCRIPTION
getting around an IE7 origin spoofing bug: http://tagneto.blogspot.com/2006/10/ie-7-breaks-iframe-apis-that-use.html if you frame the page that includes easyXDM, the attempt to redirect window.parent will fail, open a new window, and the original connection will still remain. The solution for this is to use window.top instead, which gets around IE's 7+ restriction of "Navigate sub-frames across different domains".

IE 8+ isn't affected, as they'll use PostMessage natively. In IE6, this feature was disabled by default.
