### PR TITLE
Chrome incorrectly passes HAS_NAME_PROPERTY_BUG and easyXDM dies as a result

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -455,7 +455,14 @@ function createFrame(config){
         input.style.display = "none";
         document.body.appendChild(input);
         input.name = IFRAME_PREFIX + "TEST" + channelId;
-        HAS_NAME_PROPERTY_BUG = !document.getElementsByTagName("input")[IFRAME_PREFIX + "TEST" + channelId];
+        HAS_NAME_PROPERTY_BUG = HAS_NAME_PROPERTY_BUG =  (function () {
+            for (var i = 0, el; el = document.getElementsByTagName("input")[i]; i++) {
+                if (el.name == IFRAME_PREFIX + "TEST" + channelId) {
+                    return false;
+                }
+            }
+            return true;
+        }());
         document.body.removeChild(input);
     }
     


### PR DESCRIPTION
That's because document.getElementsByTagName returns an array, not a dictionary, so you can't use [<name attribute>] against it.
