### PR TITLE
Standardize getLocation() to use toLowerCase()

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -294,7 +294,7 @@ function getLocation(url){
     if ((proto == "http:" && port == ":80") || (proto == "https:" && port == ":443")) {
         port = "";
     }
-    return proto + "//" + domain + port;
+    return (proto + "//" + domain + port).toLowerCase();
 }
 
 /**


### PR DESCRIPTION
Domains are always lowercase, although the provider might force a mixed case name. This standardizes all instances we check against event.domain (which auto-lowercases in all browsers).

Known affected implementations: Visualforce (salesforce.com)
