### PR TITLE
Fix to Disable Tracing from Running on Production Builds

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -640,7 +640,8 @@ function prepareTransportStack(config){
             // #ifdef debug
             _trace("selecting protocol: " + protocol);
             // #endif
-        } // #ifdef debug
+        }
+        // #ifdef debug
         else {
             _trace("using protocol: " + protocol);
         }


### PR DESCRIPTION
The ifdef being on the previous line was preventing proper removal of the trace blocks on the production builds.
