### PR TITLE
Update doScrollCheck function to enable minification with UglifyJS. 

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -156,20 +156,21 @@ if (!domIsReady) {
             }
         });
         if (document.documentElement.doScroll && window === top) {
-            (function doScrollCheck(){
+            var doScrollCheck = function(){
                 if (domIsReady) {
                     return;
                 }
                 // http://javascript.nwbox.com/IEContentLoaded/
                 try {
                     document.documentElement.doScroll("left");
-                } 
+                }
                 catch (e) {
                     setTimeout(doScrollCheck, 1);
                     return;
                 }
                 dom_onReady();
-            }());
+            };
+            doScrollCheck();
         }
     }
     


### PR DESCRIPTION
Uglify bug raised as https://github.com/mishoo/UglifyJS/issues/161

I've found a "browser not supported" error thrown in IE8 when the easyXDM code is minified using UglifyJS.  This simple update makes it play nice, though hopefully the Uglify folks will also issue a patch, in time.
