### PR TITLE
prevent “Do you want to display nonsecure items?” popup in ie6/7

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -491,6 +491,12 @@ function createFrame(config){
     // This is not required by easyXDM itself, but is to facilitate other use cases 
     if (HAS_NAME_PROPERTY_BUG) {
         frame = document.createElement("<iframe name=\"" + config.props.name + "\"/>");
+
+        //this is to prevent the mixed mode popup in IE6/7 when serving in a https context.
+	if(config.initialFrameSource)
+	{
+		frame.src = config.initialFrameSource;
+	}
     }
     else {
         frame = document.createElement("IFRAME");


### PR DESCRIPTION
This is adding another configuration option to prevent the mixed mode popup when running under ie6/7 it is essentially just providing a way to specify a hosted (ideally blank) page on https so the default source for the frame in those browsers doesn't cause a security popup.  There are dozens of threads about this if you google it but here is one http://www.ladysign-apps.com/blog/code/html/https-internet-explorer-nonsecure-popup/
