### PR TITLE
Chrome 13 Edge-case Bugfix in waitForReady when 'frame' is undefined

### DIFF
--- a/src/stack/PostMessageTransport.js
+++ b/src/stack/PostMessageTransport.js
@@ -108,7 +108,7 @@ easyXDM.stack.PostMessageTransport = function(config){
             if (config.isHost) {
                 // add the event handler for listening
                 var waitForReady = function(event){  
-                    if (event.data == config.channel + "-ready") {
+                    if (frame && event.data == config.channel + "-ready") {
                         // #ifdef debug
                         trace("firing onReady");
                         // #endif


### PR DESCRIPTION
In a particular users Chrome browser (who was using various extensions), 'frame' wasn't defined by the time the waitForReady function was fired, thus causing it's initialization failure.  The console was complaining about this immediately after it printed "firing onReady" in the debug output.  While it wasn't affecting anyone in our development team, verifying that 'frame' exists first seems like the correct thing to do and fixed this users problem.
