### PR TITLE
Applying the config.props to the iframe for hash

### DIFF
--- a/src/stack/HashTransport.js
+++ b/src/stack/HashTransport.js
@@ -112,10 +112,10 @@ easyXDM.stack.HashTransport = function(config){
             useParent = config.useParent;
             _remoteOrigin = getLocation(config.remote);
             if (isHost) {
-                config.props = {
+                apply(config.props, {
                     src: config.remote,
                     name: IFRAME_PREFIX + config.channel + "_provider"
-                };
+                });
                 if (useParent) {
                     config.onLoad = function(){
                         _listenerWindow = window;


### PR DESCRIPTION
When using the hash transport, the config.props was being overwritten
and losing any passed in props. This is an issue for people who specify
height, width and other properties they expect on the iframe.
