### PR TITLE
Fixed SSL mixed-content warnings for IE6

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -534,11 +534,13 @@ function createFrame(config){
         config.container = document.body;
     }
     
-    // HACK for some reason, IE needs the source set
-    // after the frame has been appended into the DOM
-    // so remove the src, and set it afterwards
+    // HACK: IE cannot have the src attribute set when the frame is appended
+    //       into the container, so we set it to "javascript:false" as a
+    //       placeholder for now.  If we left the src undefined, it would
+    //       instead default to "about:blank", which causes SSL mixed-content
+    //       warnings in IE6 when on an SSL parent page.
     var src = config.props.src;
-    delete config.props.src;
+    config.props.src = "javascript:false";
     
     // transfer properties to the frame
     apply(frame, config.props);
@@ -547,7 +549,8 @@ function createFrame(config){
     frame.allowTransparency = true;
     config.container.appendChild(frame);
     
-    // HACK see above
+    // set the frame URL to the proper value (we previously set it to
+    // "javascript:false" to work around the IE issue mentioned above)
     frame.src = src;
     config.props.src = src;
     


### PR DESCRIPTION
Since the frame `src` cannot be set until after the frame was appended into the container, the default `src` value would end up being `about:blank`.  In IE6 specifically, this causes SSL parent pages to give a mixed-content warning, since it treats `about:blank` as non-SSL.  Using `javascript:false` does not trigger the same logic in IE6, so this patch should avoid the SSL warning and still allow the `src` attribute to be set after the iframe is appended.

I tested this patch in our own application codebase, and it passed our SSL tests.  I couldn't figure out an easy way to run the easyXDM tests for this particular case, so that may be a good idea to add in the future :)
