### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ In addition the following config properties can be set for both consumer and pro
 * `onReady` - If you set this to a function, then this will be called once the communication has been established.
 * `local` {String} - To enable the NameTransport as a fallback, set this to point to the `name.html` file on the current domain.
 * `swf` {String} - To enable the FlashTransport for IE6/7 you need to point this towards your `easyxdm.swf` file. The swf must reside on one of the two domains (consumer and provider can use its own copy), or on a shared CDN used by both the consumer and provider.
-* `swfNoThrottle` {Boolean} - Set this to true if you want to have the swf/iframe placed visibly (20x20px top right corner) in order to avoid being throttled in never versions of Flash
+* `swfNoThrottle` {Boolean} - Set this to true if you want to have the swf/iframe placed visibly (20x20px top right corner) in order to avoid being throttled in newer versions of Flash
 * `swfContainer` {String || DOMElement) - Set this if you want to control where the swf is placed.
 
 These properties can be set only on the consumer


### PR DESCRIPTION
Simple text change of 'never' to 'newer' in README.md
