### PR TITLE
Refused to set unsafe header "Origin" fix

### DIFF
--- a/src/cors/index.html
+++ b/src/cors/index.html
@@ -83,7 +83,10 @@
                     }, true);
                     
                     // set the CORS request header
-                    config.headers.Origin = remote.origin;
+                    // only if there is no XHR2 features
+                    if (!XMLHttpRequest || !('withCredentials' in (new XMLHttpRequest))) {
+                        config.headers.Origin = remote.origin;
+                    }
                     
                     var isPOST = config.method == "POST";
                     


### PR DESCRIPTION
`origin` header is considered unsafe in webkit and there is an error
trying to set `origin` header
