### PR TITLE
Avoid success handler invocation on timeout

### DIFF
--- a/src/cors/index.html
+++ b/src/cors/index.html
@@ -113,9 +113,9 @@
                     // set a timeout
                     var timeout;
                     timeout = setTimeout(function(){
-                        req.abort();
                         // reset the handler
                         req.onreadystatechange = Function.prototype;
+                        req.abort();
                         req = null;
                         error({
                             message: "timeout after " + config.timeout + " second",


### PR DESCRIPTION
When timeout timer fires, abortion may invoke success handler without response data but with readyState = 4, that is confusing.
