### PR TITLE
IE6 fix for cors/index.html

### DIFF
--- a/src/cors/index.html
+++ b/src/cors/index.html
@@ -84,7 +84,7 @@
                     
                     // set the CORS request header
                     // only if there is no XHR2 features
-                    if (!window.XMLHttpRequest || !('withCredentials' in (new window.XMLHttpRequest))) {
+                    if (!window.XMLHttpRequest || !('withCredentials' in (new XMLHttpRequest))) {
                         config.headers.Origin = remote.origin;
                     }
                     


### PR DESCRIPTION
Changed XMLHttpRequest to window.XMLHttpRequest on line 87.
