### PR TITLE
clean previous message.callback to prevent unnecessary invoke in ReliableBehaivor

### DIFF
--- a/src/stack/ReliableBehavior.js
+++ b/src/stack/ReliableBehavior.js
@@ -55,6 +55,7 @@ easyXDM.stack.ReliableBehavior = function(config){
                 currentMessage = "";
                 if (callback) {
                     callback(true);
+                    callback = null;
                 }
             }
             if (message.length > 0) {


### PR DESCRIPTION
clean previous message.callback to prevent unnecessary invoke in ReliableBehaivor
