### PR TITLE
global.location may not be valid when loaded in the scope of a different object.

### DIFF
--- a/src/stack/FlashTransport.js
+++ b/src/stack/FlashTransport.js
@@ -105,7 +105,7 @@ easyXDM.stack.FlashTransport = function(config){
         }
         
         // create the object/embed
-        var flashVars = "callback=flash_loaded" + domain.replace(/[\-.]/g, "_") + "&proto=" + global.location.protocol + "&domain=" + getDomainName(global.location.href) + "&port=" + getPort(global.location.href) + "&ns=" + namespace;
+        var flashVars = "callback=flash_loaded" + domain.replace(/[\-.]/g, "_") + "&proto=" + window.location.protocol + "&domain=" + getDomainName(window.location.href) + "&port=" + getPort(window.location.href) + "&ns=" + namespace;
         // #ifdef debug
         flashVars += "&log=true";
         // #endif


### PR DESCRIPTION
Should use window.location as global/this may not always be the same as window.

P.S. Sorry about all the commits in order to get my repo in line with your master (I'm not that great with git).
