### PR TITLE
Shouldn't FlashTransport use 'window.location' instead of 'global.location'

### DIFF
--- a/src/stack/FlashTransport.js
+++ b/src/stack/FlashTransport.js
@@ -105,7 +105,7 @@ easyXDM.stack.FlashTransport = function(config){
         }
         
         // create the object/embed
-        var flashVars = "callback=flash_loaded" + domain.replace(/[\-.]/g, "_") + "&proto=" + global.location.protocol + "&domain=" + getDomainName(global.location.href) + "&port=" + getPort(global.location.href) + "&ns=" + namespace;
+        var flashVars = "callback=flash_loaded" + domain.replace(/[\-.]/g, "_") + "&proto=" + window.location.protocol + "&domain=" + getDomainName(window.location.href) + "&port=" + getPort(window.location.href) + "&ns=" + namespace;
         // #ifdef debug
         flashVars += "&log=true";
         // #endif


### PR DESCRIPTION
That way you can use `.call(myVar, ...)` at the bottom of the global closure to store easyXDM in a local variable, thus avoiding having to call `noConflict()`. If we expect `global == window`, then why pass in `window` at all?

Shouldn't this be the way it works? If not, what's the reasoning for setting `global = this` in Core.js? If so, forgive my misunderstanding.

There are no thanks great enough for easyXDM, but thanks just the same! :) - The library is a tremendous help.
