### PR TITLE
fix WidgetManager events

### DIFF
--- a/src/widgets/Widgets.js
+++ b/src/widgets/Widgets.js
@@ -65,8 +65,8 @@ easyXDM.WidgetManager = function(config){
      * @param {Object} arg
      */
     function _raiseEvent(event, arg){
-        if (config.listeners && config.listeners.event) {
-            config.listeners.event(WidgetManager, arg);
+        if (config.listeners && config.listeners[event]) {
+            config.listeners[event](WidgetManager, arg);
         }
     }
     


### PR DESCRIPTION
`event` here is one of the string values from `Events.WidgetInitialized` or `Events.WidgetFailed`. Therefore, this should be looking up that key in `config.listeners` rather than accesses the attribute named `event`.
