### PR TITLE
Parse URLs without trailing slash correctly.

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -27,7 +27,7 @@
 var global = this;
 var channelId = Math.floor(Math.random() * 10000); // randomize the initial id in case of multiple closures loaded 
 var emptyFn = Function.prototype;
-var reURI = /^((http.?:)\/\/([^:\/\s]+)(:\d+)*)/; // returns groups for protocol (2), domain (3) and port (4) 
+var reURI = /^((http.?:)\/\/([^:\?\/\s]+)(:\d+)*)/; // returns groups for protocol (2), domain (3) and port (4) 
 var reParent = /[\-\w]+\/\.\.\//; // matches a foo/../ expression 
 var reDoubleSlash = /([^:])\/\//g; // matches // anywhere but in the protocol
 var namespace = ""; // stores namespace under which easyXDM object is stored on the page (empty if object is global)


### PR DESCRIPTION
URLs like http://myurl.com?param=1 as origin weren't parsed properly.
