### PR TITLE
Update src/stack/SameOriginTransport.js

### DIFF
--- a/src/stack/SameOriginTransport.js
+++ b/src/stack/SameOriginTransport.js
@@ -84,7 +84,7 @@ easyXDM.stack.SameOriginTransport = function(config){
                 });
             }
             else {
-                send = getParentObject().Fn.get(config.channel, true)(function(msg){
+                send = getParentObject().Fn.get(config.channel, false)(function(msg){
                     pub.up.incoming(msg, targetOrigin);
                 });
                 setTimeout(function(){


### PR DESCRIPTION
Fixed issue for widget behaviour: reloading a widget throws an error because channel function was deleted the first time it was loaded.
