### PR TITLE
Add support for passing parameters to provider through hash along with existing hash

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -375,7 +375,12 @@ function appendQueryParameters(url, parameters){
             q.push(key + "=" + encodeURIComponent(parameters[key]));
         }
     }
-    return url + (useHash ? "#" : (url.indexOf("?") == -1 ? "?" : "&")) + q.join("&") + hash;
+    if(useHash) {
+      // Add parameters after existing hash, treating it like a query string
+      return url + (hash.indexOf("#") == -1 ? "#" : hash + "&") + q.join("&");
+    } else {
+      return url + (url.indexOf("?") == -1 ? "?" : "&") + q.join("&") + hash;
+    }
 }
 
 

--- a/src/tests/tests.js
+++ b/src/tests/tests.js
@@ -112,6 +112,8 @@ function runTests(){
             this.url2 = "http://foo.bar:80/a/b/c?d=e#f";
             this.url3 = "http://foo.bar:88/a/b/c?d=e#f";
             this.url4 = "hTtp://Foo.Bar:88/a/b/c?d=e#f";
+            this.url5 = "http://foo.bar:80/a/b/c?d=e#f=g&y=z";
+            this.url6 = "http://foo.bar:80/a/b/c?d=e";
             
         },
         steps: [{
@@ -146,6 +148,28 @@ function runTests(){
                     g: "h"
                 }) ===
                 "http://foo.bar:80/a/b/c?d=e&g=h#f";
+            }
+        }, {
+            name: "appendQueryParameters hash without existing hash",
+            run: function(){
+                // Override value for `hash` in config by making new easyXDM.Socket
+                socket = new easyXDM.Socket({remote:location.href, lazy:true, hash: true });
+
+                return easyXDM.appendQueryParameters(this.url6, {
+                    g: "h"
+                }) ===
+                "http://foo.bar:80/a/b/c?d=e#g=h";
+            }
+        }, {
+            name: "appendQueryParameters hash with existing hash",
+            run: function(){
+                // Override value for `hash` in config by making new easyXDM.Socket
+                socket = new easyXDM.Socket({remote:location.href, lazy:true, hash: true });
+
+                return easyXDM.appendQueryParameters(this.url5, {
+                    g: "h"
+                }) ===
+                "http://foo.bar:80/a/b/c?d=e#f=g&y=z&g=h";
             }
         }]
     }, {


### PR DESCRIPTION
This makes easyXDM play nicely with an existing hash in the URL for a provider page.

I needed this to work, because I'm passing other parameters to JavaScript running on a cached page. The caching is affected by the query string, so I want all the parameters, including easyXDM's, to be passed through the hash.

However, currently it tacks on the original hash incorrectly, like this: `/?querystring#easyxdm#original`. This small change makes it behave the same as it does with the query string: `/?querystring#original&easyxdm` and detect whether to add a `&` or `#` after the original URL + original hash.

I added some tests, but there was no simple way to change the value of `useHash`, since it's effectively a global variable setup along with a socket. Please let me know if there's some way I should change this to work nicer with the other tests.
