### PR TITLE
Set function context in easyXDM.Rpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ src/.*
 *.prefs
 build.secret.properties
 src/tests/easyXDM.debug.js
+.idea

--- a/src/Rpc.js
+++ b/src/Rpc.js
@@ -158,7 +158,9 @@ easyXDM.Rpc = function(config, jsonRpcConfig){
 	
     // set the origin 
     this.origin = getLocation(config.remote);
-	
+
+    // set context for this object's local rpc functions
+    this.context = config.context || null;
     
     /**
      * Initiates the destruction of the stack.

--- a/src/Rpc.js
+++ b/src/Rpc.js
@@ -29,7 +29,7 @@
  * Creates a proxy object that can be used to call methods implemented on the remote end of the channel, and also to provide the implementation
  * of methods to be called from the remote end.<br/>
  * The instantiated object will have methods matching those specified in <code>config.remote</code>.<br/>
- * This requires the JSON object present in the document, either natively, using json.org's json2 or as a wrapper around library spesific methods.
+ * This requires the JSON object present in the document, either natively, using json.org's json2 or as a wrapper around library specific methods.
  * <h2>How to set up</h2>
  * <pre><code>
  * var rpc = new easyXDM.Rpc({
@@ -102,7 +102,7 @@
  * &nbsp; alert("error: " + message + );
  * });
  * </code></pre>
- * Both the <code>success</code> and <code>errror</code> callbacks are optional.<br/>
+ * Both the <code>success</code> and <code>error</code> callbacks are optional.<br/>
  * When called with no callback a JSON-RPC 2.0 notification will be executed.
  * Be aware that you will not be notified of any errors with this method.
  * <br/>

--- a/src/stack/RpcBehavior.js
+++ b/src/stack/RpcBehavior.js
@@ -42,7 +42,7 @@ easyXDM.stack.RpcBehavior = function(proxy, config){
     // #endif
     var pub, serializer = config.serializer || getJSON();
     var _callbackCounter = 0, _callbacks = {};
-    
+
     /**
      * Serializes and sends the message
      * @private
@@ -52,17 +52,17 @@ easyXDM.stack.RpcBehavior = function(proxy, config){
         data.jsonrpc = "2.0";
         pub.down.outgoing(serializer.stringify(data));
     }
-    
+
     /**
      * Creates a method that implements the given definition
      * @private
-     * @param {Object} The method configuration
+     * @param {Object} definition The method configuration
      * @param {String} method The name of the method
      * @return {Function} A stub capable of proxying the requested method call
      */
     function _createMethod(definition, method){
         var slice = Array.prototype.slice;
-        
+
         // #ifdef debug
         trace("creating method " + method);
         // #endif
@@ -73,7 +73,7 @@ easyXDM.stack.RpcBehavior = function(proxy, config){
             var l = arguments.length, callback, message = {
                 method: method
             };
-            
+
             if (l > 0 && typeof arguments[l - 1] === "function") {
                 //with callback, procedure
                 if (l > 1 && typeof arguments[l - 2] === "function") {
@@ -105,13 +105,13 @@ easyXDM.stack.RpcBehavior = function(proxy, config){
             _send(message);
         };
     }
-    
+
     /**
      * Executes the exposed method
      * @private
      * @param {String} method The name of the method
      * @param {Number} id The callback id to use
-     * @param {Function} method The exposed implementation
+     * @param {Function} fn The exposed implementation
      * @param {Array} params The parameters supplied by the remote end
      */
     function _executeMethod(method, id, fn, params){
@@ -130,7 +130,7 @@ easyXDM.stack.RpcBehavior = function(proxy, config){
             }
             return;
         }
-        
+
         // #ifdef debug
         trace("requested to execute procedure " + method);
         // #endif
@@ -166,16 +166,17 @@ easyXDM.stack.RpcBehavior = function(proxy, config){
             params = [params];
         }
         try {
-            var result = fn.method.apply(fn.scope, params.concat([success, error]));
+            var context = proxy.context || fn.scope;
+            var result = fn.method.apply(context, params.concat([success, error]));
             if (!undef(result)) {
                 success(result);
             }
-        } 
+        }
         catch (ex1) {
             error(ex1.message);
         }
     }
-    
+
     return (pub = {
         incoming: function(message, origin){
             var data = serializer.parse(message);


### PR DESCRIPTION
Hello! Great library!

I have created the ability to set context for the `local` functions exposed in an easyXDM.Rpc instance. 
You can set context by setting a new `context` config parameter in the channel configuration.

```
new easyXDM.Rpc({
...
    context: window,
...
}
```

The reason I needed this functionality is because I have a Backbone model that is wrapping the Rpc object. I wanted to have control over my functions from the Backbone model itself, plus I wanted my functions exposed in the Rpc object to be easier to test.

```
providerRPC = Backbone.Model.extend({
    defaults: {
        xdmrpc: null,
        local: '/js/easyXDM/name.html',
        swf: '/js/easyXDM/easyxdm.swf'
    },
    initialize: function () {
        this.set('xdmrpc', this.createXDM());
    },
    createXDM: function () {
        // this backbone model
        var me = this;

        return new easyXDM.Rpc( {
            context: me,
            local: me.get('local'),
            swf: me.get('swf')
        }, {
            remote: {
                updateOrder: {}
            },
            local: {
                startup: me.startup
            }
        });
    },
    startup: function (data, success, error) {
        // this == the backbone model
        this.authenticate(data);
        return true;
    },
    authenticate: function (data) {
        alert("You may pass!");
    }
});
```

Thanks!

Nate
