### PR TITLE
changed onReady logic to wait for interactive state instead of complete

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -136,7 +136,7 @@ if ("readyState" in document) {
     // 'interactive' (HTML5 specs, recent WebKit builds) states.
     // https://bugs.webkit.org/show_bug.cgi?id=45119
     readyState = document.readyState;
-    domIsReady = readyState == "complete" || (~ navigator.userAgent.indexOf('AppleWebKit/') && (readyState == "loaded" || readyState == "interactive"));
+    domIsReady = readyState == "complete" || readyState == "interactive" || (~ navigator.userAgent.indexOf('AppleWebKit/') && readyState == "loaded");
 }
 else {
     // If readyState is not supported in the browser, then in order to be able to fire whenReady functions apropriately


### PR DESCRIPTION
It seems unnecessary to wait for complete. As far as I can tell, interactive state should be sufficient for anything easyxdm does.
