### PR TITLE
Only url encode when using form-urlencoded content type

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -4,7 +4,7 @@
 	<property file="build.secret.properties"/>
 	<property name="project.build.artifactdir" value="./artifacts/"/>
 	<property name="project.build.publishdir" value="./artifacts/"/>
-	<property name="project.build.version" value="2.4.18"/>
+	<property name="project.build.version" value="2.4.19"/>
 	
 	<!-- Setup classpath for js-build-tools ant tasks -->
 	<path id="js-build-tasks.classpath">

--- a/src/Fn.js
+++ b/src/Fn.js
@@ -58,6 +58,9 @@
             // #ifdef debug
             this._trace("retrieving function " + name);
             // #endif
+            if (!_map.hasOwnProperty(name)) {
+                return;
+            }
             var fn = _map[name];
             // #ifdef debug
             if (!fn) {

--- a/src/changes.html
+++ b/src/changes.html
@@ -10,7 +10,7 @@
                 <br/>
                 Removed XSS vulnerability:
                 <br/>
-                - XSS due to lack of validation in name.html (CVE-2014-1403) - disclosed by Krzystof Kotowicz (Cure53)
+                - XSS due to lack of validation in name.html (CVE-2014-1403) - disclosed by <a href="http://blog.kotowicz.net">Krzystof Kotowicz</a>
             </li>
             <li>
                 2.4.18 21.09.13

--- a/src/changes.html
+++ b/src/changes.html
@@ -5,6 +5,13 @@
     </head>
     <body>
         <ul>
+             <li>
+                2.4.19 18.01.14
+                <br/>
+                Removed XSS vulnerability:
+                <br/>
+                - XSS due to lack of validation in name.html (CVE-2014-1403) - disclosed by Krzystof Kotowicz (Cure53)
+            </li>
             <li>
                 2.4.18 21.09.13
                 <br/>

--- a/src/cors/index.html
+++ b/src/cors/index.html
@@ -10,8 +10,8 @@
             easyXDM.DomHelper.requiresJSON("../json2.js");
         </script>
         <script type="text/javascript">
-        
-        /* 
+
+        /*
          * This is a CORS (Cross-Origin Resource Sharing) and AJAX enabled endpoint for easyXDM.
          * The ACL code is adapted from pmxdr (http://github.com/eligrey/pmxdr/) by Eli Grey (http://eligrey.com/)
          *
@@ -23,7 +23,7 @@
             (!!(t == 'object' && object[property])) ||
             t == 'unknown';
         }
-        
+
         /**
          * Creates a cross-browser XMLHttpRequest object
          * @return {XMLHttpRequest} A XMLHttpRequest object.
@@ -42,7 +42,7 @@
                             item = list[i] + ".XMLHTTP";
                             var obj = new ActiveXObject(item);
                             return item;
-                        } 
+                        }
                         catch (e) {
                         }
                     }
@@ -52,13 +52,13 @@
                 };
             }
         }());
-        
+
         // this file is by default set up to use Access Control - this means that it will use the headers set by the server to decide whether or not to allow the call to return
         var useAccessControl = true;
         // always trusted origins, can be exact strings or regular expressions
         var alwaysTrustedOrigins = [(/\.?easyxdm\.net/), (/xdm1/)];
-        
-        // instantiate a new easyXDM object which will handle the request 
+
+        // instantiate a new easyXDM object which will handle the request
         var remote = new easyXDM.Rpc({
             local: "../name.html",
             swf: "../easyxdm.swf"
@@ -66,7 +66,7 @@
             local: {
                 // define the exposed method
                 request: function(config, success, error){
-                
+
                     // apply default values if not set
                     easyXDM.apply(config, {
                         method: "POST",
@@ -81,38 +81,45 @@
                         data: {},
                         timeout: 10 * 1000
                     }, true);
-                    
+
                     // set the CORS request header
                     // only if there is no XHR2 features
                     if (!window.XMLHttpRequest || !('withCredentials' in (new XMLHttpRequest))) {
                         config.headers.Origin = remote.origin;
                     }
-                    
+
                     var isPOST = config.method == "POST";
-                    
-                    // convert the data into a format we can send to the server 
-                    var pairs = [];
-                    for (var key in config.data) {
-                        if (config.data.hasOwnProperty(key)) {
-                            pairs.push(encodeURIComponent(key) + "=" + encodeURIComponent(config.data[key]));
-                        }
+
+                    if (config.headers["Content-Type"] == "application/x-www-form-urlencoded")
+					{
+						var pairs = [];
+						for (var key in config.data) {
+							if (config.data.hasOwnProperty(key)) {
+								pairs.push(encodeURIComponent(key) + "=" + encodeURIComponent(config.data[key]));
+							}
+						}
+						var data = pairs.join("&");
+
+					}
+					else
+					{
+						data = config.data;
                     }
-                    var data = pairs.join("&");
-                    
+
                     // create the XMLHttpRequest object
                     var req = getXhr();
                     var url = !isPOST && data
                         ? config.url + (~config.url.indexOf('?') ? '&' : '?') + data
                         : config.url;
                     req.open(config.method, url, true);
-                    
+
                     // apply the request headers
                     for (var prop in config.headers) {
                         if (config.headers.hasOwnProperty(prop) && config.headers[prop]) {
                             req.setRequestHeader(prop, config.headers[prop]);
                         }
                     }
-                    
+
                     // set a timeout
                     var timeout;
                     timeout = setTimeout(function(){
@@ -129,7 +136,7 @@
                             }
                         }, null);
                     }, config.timeout);
-                    
+
                     // check if this origin should always be trusted
                     var alwaysTrusted = false, i = alwaysTrustedOrigins.length;
                     while (i-- && !alwaysTrusted) {
@@ -140,19 +147,19 @@
                             alwaysTrusted = (remote.origin === alwaysTrustedOrigins[i]);
                         }
                     }
-                    
-                    
+
+
                     // define the onreadystate handler
                     req.onreadystatechange = function(){
                         if (req.readyState == 4) {
                             clearTimeout(timeout);
-                            
+
                             // parse the response headers
                             var rawHeaders = req.getAllResponseHeaders(), headers = {}, headers_lowercase = {}, reHeader = /([\w-_]+):\s+(.*)$/gm, m;
                             while ((m = reHeader.exec(rawHeaders))) {
                                 headers_lowercase[m[1].toLowerCase()] = headers[m[1]] = m[2];
                             }
-                            
+
                             if (req.status < 200 || req.status >= 300) {
                                 if (useAccessControl) {
                                     error("INVALID_STATUS_CODE");
@@ -165,13 +172,13 @@
                                 }
                             }
                             else {
-                            
+
                                 var errorMessage;
                                 if (useAccessControl) {
                                     // normalize the valuse access controls
                                     var aclAllowedOrigin = (headers_lowercase["access-control-allow-origin"] || "").replace(/\s/g, "");
                                     var aclAllowedMethods = (headers_lowercase["access-control-allow-methods"] || "").replace(/\s/g, "");
-                                    
+
                                     // determine if origin is trusted
                                     if (alwaysTrusted || aclAllowedOrigin == "*" || aclAllowedOrigin.indexOf(remote.origin) != -1) {
                                         // determine if the request method was allowed
@@ -182,9 +189,9 @@
                                     else {
                                         errorMessage = "DISALLOWED_ORIGIN";
                                     }
-                                    
+
                                 }
-                                
+
                                 if (errorMessage) {
                                     error(errorMessage);
                                 }
@@ -201,7 +208,7 @@
                             req = null;
                         }
                     };
-                    
+
                     // issue the request
                     req.send(isPOST ? data : "");
                 }

--- a/src/name.html
+++ b/src/name.html
@@ -24,6 +24,9 @@
                 else {
                     channel = hash.substring(0, indexOf);
                     url = decodeURIComponent(hash.substring(indexOf + 1));
+                    if (url && !/https?:\/\//.test(url)) {
+                        throw new Error('Invalid url');
+                    }
                 }
                 switch (location.hash.substring(2, 3)) {
                     case "2":

--- a/src/name.html
+++ b/src/name.html
@@ -24,7 +24,7 @@
                 else {
                     channel = hash.substring(0, indexOf);
                     url = decodeURIComponent(hash.substring(indexOf + 1));
-                    if (url && !/https?:\/\//.test(url)) {
+                    if (url && !/^https?:\/\//.test(url)) {
                         throw new Error('Invalid url');
                     }
                 }


### PR DESCRIPTION
When using ASP.NET WebAPI with  "Content-Type": "application/json", the
form-urlencoding invalidates the JSON.

//Example
rpc.request({
url: HLeasyXDM.WebAPIFullUrl + uri,
method: reqType,
data: JSON.stringify(data),
headers: {
"blaKey": blaKey,
"blaToken": blaToken,
"Accept": "application/json",
"Content-Type": "application/json"
}
};
