### PR TITLE
Fixed config.isHost not respecting an explicit 'false' value

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -614,7 +614,7 @@ function checkAcl(acl, domain){
  */
 function prepareTransportStack(config){
     var protocol = config.protocol, stackEls;
-    config.isHost = config.isHost || undef(query.xdm_p);
+    config.isHost = undef(config.isHost) ? undef(query.xdm_p) : !!config.isHost;
     useHash = config.hash || false;
     // #ifdef debug
     _trace("preparing transport stack");


### PR DESCRIPTION
If you explicitly set isHost to be 'false', it defaults to using the query to determine whether or not its a consumer or provider. This should fix it without breaking previous functionality.
