### PR TITLE
Adding copyright message to cors

### DIFF
--- a/src/cors/index.html
+++ b/src/cors/index.html
@@ -11,10 +11,10 @@
         </script>
         <script type="text/javascript">
         
-        // Copyright (c) 2010 Eli Grey
-        // MIT license: https://github.com/eligrey/pmxdr/blob/master/LICENSE.md
-        
         /* 
+         * Copyright (c) 2010 Eli Grey
+         * MIT license: https://github.com/eligrey/pmxdr/blob/master/LICENSE.md
+         *
          * This is a CORS (Cross-Origin Resource Sharing) and AJAX enabled endpoint for easyXDM.
          * The ACL code is adapted from pmxdr (http://github.com/eligrey/pmxdr/) by Eli Grey (http://eligrey.com/)
          *


### PR DESCRIPTION
I see the attribution, though it looks like you forgot the copyright message and license back when this got added years ago. Thanks for using pmxdr all this time :)
