### PR TITLE
Fix the problem with exception after receiving msg from another source.

### DIFF
--- a/src/stack/PostMessageTransport.js
+++ b/src/stack/PostMessageTransport.js
@@ -77,7 +77,7 @@ easyXDM.stack.PostMessageTransport = function(config){
         // #ifdef debug
         trace("received message '" + event.data + "' from " + origin);
         // #endif
-        if (origin == targetOrigin && event.data.substring(0, config.channel.length + 1) == config.channel + " ") {
+        if (origin == targetOrigin && typeof event.data === 'string' && event.data.substring(0, config.channel.length + 1) == config.channel + " ") {
             pub.up.incoming(event.data.substring(config.channel.length + 1), origin);
         }
     }


### PR DESCRIPTION
The exception is thrown when `event.data` is another type than string.
This is a case when using easyXDM and XDomain at the same time.
