### PR TITLE
Fix ACL support so that dot only matches dot unless regexp syntax is used

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -596,7 +596,7 @@ function checkAcl(acl, domain){
     var re, i = acl.length;
     while (i--) {
         re = acl[i];
-        re = new RegExp(re.substr(0, 1) == "^" ? re : ("^" + re.replace(/(\*)/g, ".$1").replace(/\?/g, ".") + "$"));
+        re = new RegExp(re.substr(0, 1) == "^" ? re : ("^" + re.replace(/\./g, "\\.").replace(/\*/g, ".*").replace(/\?/g, ".") + "$"));
         if (re.test(domain)) {
             return true;
         }

--- a/src/tests/tests.js
+++ b/src/tests/tests.js
@@ -174,6 +174,11 @@ function runTests(){
                 return easyXDM.checkAcl(this.acl, "http://domainb.com");
             }
         }, {
+            name: "Dot only matches dot",
+            run: function(){
+                return !easyXDM.checkAcl(this.acl, "http://wwwXdomain.invalid");
+            }
+        }, {
             name: "Match RegExp",
             run: function(){
                 return easyXDM.checkAcl(this.acl, "http://domcccain.com");


### PR DESCRIPTION
Previously if ACL is specified using simple wildcard expression (not regexp starting with "^") dot character matched any character. For example if ACL expression was "http://www.domain.com", domain "http://wwwXdomain.com" was incorrectly considered as matching.
