### PR TITLE
Workaround for false positive HAS_NAME_PROPERTY_BUG detection

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -501,11 +501,19 @@ function createFrame(config){
         testForNamePropertyBug();
     }
     var frame;
-    // This is to work around the problems in IE6/7 with setting the name property. 
+    // This is to work around the problems in IE6/7 with setting the name property.
     // Internally this is set as 'submitName' instead when using 'iframe.name = ...'
-    // This is not required by easyXDM itself, but is to facilitate other use cases 
+    // This is not required by easyXDM itself, but is to facilitate other use cases
     if (HAS_NAME_PROPERTY_BUG) {
-        frame = document.createElement("<iframe name=\"" + config.props.name + "\"/>");
+	try {
+	    frame = document.createElement("<iframe name=\"" + config.props.name + "\"/>");
+	}
+	catch(e) {
+	    // Due to people phasing out IE6/7 support form.elements behaviour may be altered
+	    // to falsely trigger the HAS_NAME_PROPERTY_BUG
+	    frame = document.createElement("IFRAME");
+	    frame.name = config.props.name;
+	}
     }
     else {
         frame = document.createElement("IFRAME");


### PR DESCRIPTION
I'm hitting a bit of a catch-22. A lot of libraries are dropping support for IE6/7 and therefor stopped caring about the behaviour of form.elements. This behaviour is instrumental for the HAS_NAME_PROPERTY_BUG detection done in easyXDM. We were hitting a false positive on Safari when using a webcomponents shim.

So this isn't a problem with easyXDM itself but I did find a relatively easy way to fix it by wrapping the iframe creation in a try/catch block. I noticed #126 has a similar issue with Firefox so I'm assuming this could also fix that problem.
