### PR TITLE
Avoid throwing on invalid onMessage messages

### DIFF
--- a/src/stack/PostMessageTransport.js
+++ b/src/stack/PostMessageTransport.js
@@ -73,6 +73,10 @@ easyXDM.stack.PostMessageTransport = function(config){
      * @param {Object} event The messageevent
      */
     function _window_onMessage(event){
+        if (typeof event.data !== "string") {
+            // postMessage also supports passing objects, but easyXDM's messages are always strings
+            return;
+        }
         var origin = _getOrigin(event);
         // #ifdef debug
         trace("received message '" + event.data + "' from " + origin);


### PR DESCRIPTION
postMessage also supports passing objects, but since this code is currently expecting only strings, it tries to call .substring on a potential object. 
Avoid this by gating on the type of `data`.