### PR TITLE
Fix checkacl

### DIFF
--- a/src/Core.js
+++ b/src/Core.js
@@ -589,6 +589,11 @@ function createFrame(config){
  * @return {Boolean} True if the domain is allowed, false if not.
  */
 function checkAcl(acl, domain){
+	// No need to check cross-domain communication as we are in the same domain.
+	if (getLocation(location.href) == getLocation(domain)) {		
+		return true;
+	}
+
     // normalize into an array
     if (typeof acl == "string") {
         acl = [acl];
@@ -596,7 +601,7 @@ function checkAcl(acl, domain){
     var re, i = acl.length;
     while (i--) {
         re = acl[i];
-        re = new RegExp(re.substr(0, 1) == "^" ? re : ("^" + re.replace(/(\*)/g, ".$1").replace(/\?/g, ".") + "$"));
+        re = new RegExp(re.substr(0, 1) == "^" ? re : ("^" + re.replace(/\./g, "\\.").replace(/(\*)/g, ".$1").replace(/\?/g, ".") + "$"));
         if (re.test(domain)) {
             return true;
         }


### PR DESCRIPTION
I fixed 2 bugs in checkacl method
1. Requests from the same domain should always be allowed, no matter what acl list is like.
if (getLocation(location.href) == getLocation(domain)) {

return true;
}
2. .domain.com is converted to /^..domain.com$/, which is clearly a bug as http://evildomain.com will also be mached. I escaped . in the regex, so that the generated regex will be /^.*.domain.com$/
