### PR TITLE
avoid post message parse errors

### DIFF
--- a/src/stack/PostMessageTransport.js
+++ b/src/stack/PostMessageTransport.js
@@ -81,7 +81,7 @@ easyXDM.stack.PostMessageTransport = function(config){
         // #ifdef debug
         trace("received message '" + event.data + "' from " + origin);
         // #endif
-        if (origin == targetOrigin && (typeof myVar === 'string' || myVar instanceof String) && event.data.substring(0, config.channel.length + 1) == config.channel + " ") {
+        if (origin == targetOrigin && (typeof event.data === 'string' || event.data instanceof String) && event.data.substring(0, config.channel.length + 1) == config.channel + " ") {
             pub.up.incoming(event.data.substring(config.channel.length + 1), origin);
         }
     }

--- a/src/stack/PostMessageTransport.js
+++ b/src/stack/PostMessageTransport.js
@@ -81,7 +81,7 @@ easyXDM.stack.PostMessageTransport = function(config){
         // #ifdef debug
         trace("received message '" + event.data + "' from " + origin);
         // #endif
-        if (origin == targetOrigin && event.data.substring(0, config.channel.length + 1) == config.channel + " ") {
+        if (origin == targetOrigin && (typeof myVar === 'string' || myVar instanceof String) && event.data.substring(0, config.channel.length + 1) == config.channel + " ") {
             pub.up.incoming(event.data.substring(config.channel.length + 1), origin);
         }
     }


### PR DESCRIPTION
EasyXDM produces errors when it receives post messages which have attached data objects. Therefore, I added a condition.
