### PR TITLE
Increase compatibility build.sh script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
-#!/bin/bash
+#!/usr/bin/env bash
 tools/apache-ant-1.7.1/bin/ant


### PR DESCRIPTION
Make `bash.sh` script more compatible with distros like `NixOS` which not have bash in that location.