### PR TITLE
Fix ACL checking to be safer for non-regex domains

### DIFF
--- a/src/tests/tests.js
+++ b/src/tests/tests.js
@@ -185,6 +185,16 @@ function runTests(){
                 return easyXDM.checkAcl(this.acl, "http://domcccain.com");
             }
         }, {
+            name: "No match * with wildcard",
+            run: function(){
+                return !easyXDM.checkAcl(this.acl, "http://nodomaina.com");
+            }
+        }, {
+            name: "No match non RegExp as RegExp",
+            run: function(){
+                return !easyXDM.checkAcl(this.acl, "http://www2domain.invalid");
+            }
+        }, {
             name: "No match",
             run: function(){
                 return !easyXDM.checkAcl(this.acl, "http://foo.com");


### PR DESCRIPTION
**Problem**
Currently the documentation reads:

acl {String || String[]} 
Use this to only allow specific domains to consume this provider. The patterns can contain the wildcards ? and * as in the examples 'http://example.com', '*.foo.com' and '*dom?.com', or they can be regular expressions starting with ^ and ending with $. If none of the patterns match an Error will be thrown.

Reading that documentation, it seems to a user there are two options:
1) 'https://*.example.com' should match any subdomain of example.com, treated as a string with */? options mapping to regex.
2) I provide stringy regex '^https://.*\\.twitter\\.com$' and it's treated as regex.

However, in the code, it appears that the string (example 1) is always treated as regex. This means in example one, where I said it should match any sub-domain, it actually matches https://go2example.com as well.

This inadvertent treatment is inconsistent with the documentation and means that a user might input a direct string, and unexpectedly have it treated as regex with unintended consequences.

**Solution**
Match the code to the documentation, requiring that both ^ and $ are actually specified in order to be used as direct regex. Also escape any strings before converting them to regex to reduce mistakes and increase security